### PR TITLE
Sort strings based on locale

### DIFF
--- a/knockout.bindings.orderable.js
+++ b/knockout.bindings.orderable.js
@@ -1,5 +1,8 @@
 ﻿ko.bindingHandlers.orderable = {
     compare: function (left, right) {
+        if (typeof left === 'string' || typeof right === 'string') {
+            return left.localeCompare(right);
+        }
         if (left > right)
             return 1;
 


### PR DESCRIPTION
Old sort was putting lowercase after uppercase, instead of intermixed.
