### PR TITLE
Nulls in the data were causing errors, fixed

### DIFF
--- a/knockout.bindings.orderable.js
+++ b/knockout.bindings.orderable.js
@@ -16,6 +16,12 @@
     },
 
     compare: function (left, right) {
+	    if (typeof left === "undefined" || left === null) {
+            return -1;
+        }
+        if (typeof right === "undefined" || right === null) {
+            return 1;
+        }
         if (typeof left === 'string' || typeof right === 'string') {
             return left.localeCompare(right);
         }


### PR DESCRIPTION
In the compare function, I was getting errors because left and/or right were null in my data.  Not sure why my setup was different or would cause the issue, but this fixed it for me.
