### PR TITLE
Allow sorting by a nullable field

### DIFF
--- a/knockout.bindings.orderable.js
+++ b/knockout.bindings.orderable.js
@@ -17,7 +17,7 @@
 
     compare: function (left, right) {
         if (typeof left === 'string' || typeof right === 'string') {
-            return left.localeCompare(right);
+            return left ? left.localeCompare(right) : 1;
         }
         if (left > right)
             return 1;


### PR DESCRIPTION
When sorting by a nullable field, the original code throws a null reference error when trying to call localeCompare on the left variable.  The new code simply performs a null check before trying to call localeCompare.  If the left variable is null, the method now returns 1.